### PR TITLE
[CLOUD-345] Upgrade kieserver and decisionserver from 6.2.0.ER4 to 6.2.0.CR1

### DIFF
--- a/decisionserver/hellorules-client/pom.xml
+++ b/decisionserver/hellorules-client/pom.xml
@@ -25,13 +25,16 @@
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
+        <!-- NOTE: the "*-redhat-4" version can temporarily only be accessed by
+             downloading the zip version of that maven release's repository -->
+        <kie.version>6.3.0.Final-redhat-4</kie.version>
     </properties>
 
    <dependencies>
       <dependency>
-         <groupId>javax.servlet</groupId>
-         <artifactId>javax.servlet-api</artifactId>
-         <version>3.0.1</version>
+         <groupId>org.jboss.spec.javax.servlet</groupId>
+         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+         <version>1.0.2.Final-redhat-2</version>
          <scope>provided</scope>
       </dependency>
       <dependency>
@@ -43,13 +46,13 @@
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-client</artifactId>
-         <version>5.11.0</version>
+         <version>5.11.1</version>
          <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.drools</groupId>
          <artifactId>drools-compiler</artifactId>
-         <version>6.3.0.Final</version>
+         <version>${kie.version}</version>
          <scope>compile</scope>
       </dependency>
       <dependency>
@@ -73,14 +76,14 @@
       <dependency>
          <groupId>org.kie.server</groupId>
          <artifactId>kie-server-client</artifactId>
-         <version>6.3.0.Final</version>
+         <version>${kie.version}</version>
          <scope>compile</scope>
       </dependency>
       <!-- for remote debugging of MDB
       <dependency>
          <groupId>org.kie.server</groupId>
          <artifactId>kie-server-jms</artifactId>
-         <version>6.3.0.Final</version>
+         <version>${kie.version}</version>
          <scope>compile</scope>
       </dependency>
       -->


### PR DESCRIPTION
[CLOUD-345] Upgrade kieserver and decisionserver from 6.2.0.ER4 to 6.2.0.CR1
https://issues.jboss.org/browse/CLOUD-345