### PR TITLE
CLOUD-641: Add multi-version Container support to KIE Server

### DIFF
--- a/decisionserver/hellorules-client/pom.xml
+++ b/decisionserver/hellorules-client/pom.xml
@@ -6,8 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-parent-with-dependencies</artifactId>
-        <!-- NOTE: the "*-redhat-*" version can be accessed by downloading the zip version of that maven release's repository -->
-        <version>6.4.0.Final-redhat-1</version>
+        <version>6.4.0.Final</version>
     </parent>
 
     <groupId>org.openshift.quickstarts</groupId>
@@ -96,13 +95,6 @@
             <artifactId>kie-server-client</artifactId>
             <scope>compile</scope>
         </dependency>
-        <!-- for remote debugging of MDB
-        <dependency>
-            <groupId>org.kie.server</groupId>
-            <artifactId>kie-server-jms</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.openshift.quickstarts</groupId>
             <artifactId>decisionserver-hellorules</artifactId>

--- a/processserver/library-client/pom.xml
+++ b/processserver/library-client/pom.xml
@@ -6,8 +6,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-parent-with-dependencies</artifactId>
-        <!-- NOTE: the "*-redhat-*" version can be accessed by downloading the zip version of that maven release's repository -->
-        <version>6.4.0.Final-redhat-1</version>
+        <version>6.4.0.Final</version>
     </parent>
 
     <groupId>org.openshift.quickstarts</groupId>
@@ -116,13 +115,6 @@
             <artifactId>kie-server-client</artifactId>
             <scope>compile</scope>
         </dependency>
-        <!-- for remote debugging of MDB
-        <dependency>
-            <groupId>org.kie.server</groupId>
-            <artifactId>kie-server-jms</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.openshift.quickstarts</groupId>
             <artifactId>processserver-library</artifactId>


### PR DESCRIPTION
CLOUD-641: Add multi-version Container support to KIE Server
https://issues.jboss.org/browse/CLOUD-641