### PR TITLE
Profile added to create ROOT.war on openshift

### DIFF
--- a/tomcat-websocket-chat/pom.xml
+++ b/tomcat-websocket-chat/pom.xml
@@ -43,6 +43,7 @@
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
+        <version.war.plugin>2.6</version.war.plugin>
     </properties>
 
 
@@ -66,4 +67,30 @@
             given to the generated war, and hence the context root) -->
         <finalName>${project.artifactId}</finalName>
     </build>
+
+    <profiles>
+        <profile>
+        <!-- When built in OpenShift the 'openshift' profile will be used when 
+            invoking mvn. -->
+        <!-- Use this profile for any OpenShift specific customization your app 
+            will need. -->
+        <!-- By default that is to put the resulting archive into the 'deployments' 
+            folder. -->
+        <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+        <id>openshift</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${version.war.plugin}</version>
+                    <configuration>
+                        <outputDirectory>deployments</outputDirectory>
+                        <warName>ROOT</warName>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+        </profile>
+
+    </profiles>
 </project>


### PR DESCRIPTION
The tomcat-websocket-chat app is used as the default app in the jboss-webserver30-tomcat7-openshift template:
https://github.com/jboss-openshift/application-templates/blob/master/webserver/jws30-tomcat7-basic-s2i.json

The app gets deployed under /websocket-chat which is confusing for new users who don't know OpenShift well and click on the route url.