### PR TITLE
Change location of database files

### DIFF
--- a/datavirt/dynamicvdb-datafederation/datasources.env
+++ b/datavirt/dynamicvdb-datafederation/datasources.env
@@ -17,7 +17,7 @@ ACCOUNTS_H2_JTA=true
 ACCOUNTS_H2_NONXA=true
 ACCOUNTS_H2_USERNAME=sa
 ACCOUNTS_H2_PASSWORD=sa
-ACCOUNTS_H2_URL="jdbc:h2:/home/jboss/source/data/databases/h2/accounts"
+ACCOUNTS_H2_URL="jdbc:h2:/opt/eap/standalone/data/databases/h2/accounts"
 # required, but unused...
 ACCOUNTS_H2_SERVICE_HOST=dummy
 ACCOUNTS_H2_SERVICE_PORT=12345
@@ -31,7 +31,7 @@ ACCOUNTS_DERBY_PASSWORD=derby
 ACCOUNTS_DERBY_TX_ISOLATION=TRANSACTION_READ_UNCOMMITTED
 ACCOUNTS_DERBY_JTA=true
 # Connection info for xa datasource
-ACCOUNTS_DERBY_XA_CONNECTION_PROPERTY_DatabaseName=/home/jboss/source/data/databases/derby/accounts
+ACCOUNTS_DERBY_XA_CONNECTION_PROPERTY_DatabaseName=/opt/eap/standalone/data/databases/derby/accounts
 # _HOST and _PORT are required, but not used
 ACCOUNTS_DERBY_SERVICE_HOST=dummy
 ACCOUNTS_DERBY_SERVICE_PORT=1527
@@ -94,7 +94,7 @@ MARKETDATA_MODULE_ID=org.jboss.teiid.resource-adapter.file
 MARKETDATA_MODULE_SLOT=main
 MARKETDATA_CONNECTION_CLASS=org.teiid.resource.adapter.file.FileManagedConnectionFactory
 MARKETDATA_CONNECTION_JNDI=java:/marketdata-file
-MARKETDATA_PROPERTY_ParentDirectory='/home/jboss/source/data/teiidfiles/data'
+MARKETDATA_PROPERTY_ParentDirectory='/opt/eap/standalone/data/teiidfiles/data'
 MARKETDATA_PROPERTY_AllowParentPaths=true
 
 # The "Excel" files.
@@ -104,7 +104,7 @@ EXCEL_MODULE_SLOT=main
 EXCEL_MODULE_ID=org.jboss.teiid.resource-adapter.file
 EXCEL_CONNECTION_CLASS=org.teiid.resource.adapter.file.FileManagedConnectionFactory
 EXCEL_CONNECTION_JNDI=java:/excel-file
-EXCEL_PROPERTY_ParentDirectory='/home/jboss/source/data/teiidfiles/excelFiles/'
+EXCEL_PROPERTY_ParentDirectory='/opt/eap/standalone/data/teiidfiles/excelFiles/'
 EXCEL_PROPERTY_AllowParentPaths=true
 
 # JDG configuration for materialization cache


### PR DESCRIPTION
CLOUD-1650 will stop the sources from being copied into ~jboss/source,
but the data sub-directory can be copied into /opt/eap/standalone/data
if $APP_DATADIR is defined properly. Adjust the paths assuming this is
the case.