### PR TITLE
[CLOUD-2192] new version of datasources.env, hibernate-portfolio-vdb.xml, jdg-mat-cache-vdb.xml

### DIFF
--- a/datavirt64/dynamicvdb-datafederation/app/datagrid-materialization/src/vdb/jdg-mat-cache-vdb.xml
+++ b/datavirt64/dynamicvdb-datafederation/app/datagrid-materialization/src/vdb/jdg-mat-cache-vdb.xml
@@ -9,9 +9,9 @@
 	<source connection-jndi-name="java:/infinispanRemoteDSL" name="infinispan" translator-name="ispn-override"/>
 
      <metadata type = "DDL"><![CDATA[
-            CREATE FOREIGN TABLE StockCache (product_id integer PRIMARY KEY, symbol string(10), price double, company_name string(100) ) OPTIONS(UPDATABLE true, "teiid_ispn:cache" 'stockCache');
+            CREATE FOREIGN TABLE StockCache (id integer, product_id integer PRIMARY KEY, symbol string(10), price double, company_name string(100) ) OPTIONS(UPDATABLE true, "teiid_ispn:cache" 'stockCache');
 
-           CREATE FOREIGN TABLE ST_StockCache (product_id integer PRIMARY KEY, symbol string(10), price double, company_name string(100) ) OPTIONS(UPDATABLE true, "teiid_ispn:cache" 'st_stockCache');
+           CREATE FOREIGN TABLE ST_StockCache (id integer, product_id integer PRIMARY KEY, symbol string(10), price double, company_name string(100) ) OPTIONS(UPDATABLE true, "teiid_ispn:cache" 'ST_stockCache');
 
         ]]>
        </metadata>
@@ -22,7 +22,7 @@
 
         <model name="StocksMatView" type="VIRTUAL">
                 <metadata type="DDL"><![CDATA[
-CREATE VIEW Stock (
+CREATE VIEW Stock (id integer PRIMARY KEY,
 	product_id integer,
 	symbol string,
 	price double,
@@ -36,7 +36,7 @@ MATERIALIZED_TABLE 'StockJDGSource.StockCache',
 "teiid_rel:MATVIEW_TTL" 10000,
 "teiid_rel:MATVIEW_ONERROR_ACTION" 'WAIT')
 AS
-	SELECT
+	SELECT  ROW_NUMBER() OVER (ORDER BY Stocks.Stock.product_id) as id,
 		Stocks.Stock.product_id, Stocks.Stock.symbol, CAST(Stocks.Stock.price AS double) AS price, Stocks.Stock.company_name
 	FROM
 		Stocks.Stock;

--- a/datavirt64/dynamicvdb-datafederation/app/hibernate-portfolio-vdb.xml
+++ b/datavirt64/dynamicvdb-datafederation/app/hibernate-portfolio-vdb.xml
@@ -10,8 +10,8 @@
 
     <model name="ProductPricingModel" type="VIRTUAL">
          <metadata type="DDL"><![CDATA[
-            CREATE VIEW ProductInfo (id integer OPTIONS(UPDATABLE 'TRUE'), symbol varchar(10) OPTIONS(UPDATABLE 'TRUE'), companyName varchar(100) OPTIONS(UPDATABLE 'TRUE'), price decimal OPTIONS(UPDATABLE 'FALSE') ) OPTIONS (UPDATABLE 'TRUE'  ) AS 
-select P.id, P.symbol, P.company_name, S.price from Accounts.product as P, (call MarketData.getTextFiles('*.txt')) f, TEXTTABLE(f.file COLUMNS symbol string, price bigdecimal HEADER) as S where P.symbol=S.symbol;
+            CREATE VIEW ProductInfo (myid integer PRIMARY KEY, id integer OPTIONS(UPDATABLE 'TRUE'), symbol varchar(10) OPTIONS(UPDATABLE 'TRUE'), companyName varchar(100) OPTIONS(UPDATABLE 'TRUE'), price decimal OPTIONS(UPDATABLE 'FALSE') ) OPTIONS (UPDATABLE 'TRUE'  ) AS 
+select ROW_NUMBER() OVER (ORDER BY P.id) as myid, P.id, P.symbol, P.company_name, S.price from Accounts.product as P, (call MarketData.getTextFiles('*.txt')) f, TEXTTABLE(f.file COLUMNS symbol string, price bigdecimal HEADER) as S where P.symbol=S.symbol;
  
  			CREATE TRIGGER ON ProductInfo INSTEAD OF INSERT AS
  			   FOR EACH ROW

--- a/datavirt64/dynamicvdb-datafederation/datasources.env
+++ b/datavirt64/dynamicvdb-datafederation/datasources.env
@@ -83,7 +83,7 @@ RESOURCE_ADAPTERS=MARKETDATA,EXCEL
 
 # Automatically add in the MAT_CACHE configuration, if we've included the
 # materialization VDB
-if [ -f "/deployments/jdg-remote-cache-mat-vdb.xml" ]; then
+if [ -f "/deployments/jdg-mat-cache-vdb.xml" ]; then
   RESOURCE_ADAPTERS=${RESOURCE_ADAPTERS},MAT_CACHE
 fi
 
@@ -116,3 +116,8 @@ MAT_CACHE_MODULE_ID=org.jboss.teiid.resource-adapter.infinispan.hotrod
 MAT_CACHE_CONNECTION_CLASS=org.teiid.resource.adapter.infinispan.hotrod.InfinispanManagedConnectionFactory
 MAT_CACHE_CONNECTION_JNDI=java:/infinispanRemoteDSL
 MAT_CACHE_PROPERTY_RemoteServerList=${DATAGRID_APP_HOTROD_SERVICE_HOST}:${DATAGRID_APP_HOTROD_SERVICE_PORT}
+MAT_CACHE_PROPERTY_UserName=jdg
+MAT_CACHE_PROPERTY_Password=JBoss.123
+MAT_CACHE_PROPERTY_AuthenticationRealm=ApplicationRealm
+MAT_CACHE_PROPERTY_AuthenticationServerName=jdg-server
+MAT_CACHE_PROPERTY_SaslMechanism=DIGEST-MD5


### PR DESCRIPTION
datasources.env row
`if [ -f "/deployments/jdg-remote-cache-mat-vdb.xml" ]; then`
changed to:
`if [ -f "/deployments/jdg-mat-cache-vdb.xml" ]; then  `
added:
MAT_CACHE_PROPERTY_UserName=jdg
MAT_CACHE_PROPERTY_Password=JBoss.123
MAT_CACHE_PROPERTY_AuthenticationRealm=ApplicationRealm
MAT_CACHE_PROPERTY_AuthenticationServerName=jdg-server
MAT_CACHE_PROPERTY_SaslMechanism=DIGEST-MD5

jdg-mat-cache-vdb.xml:
fixed st_stockCache -> ST_stockCache
added primary key

hibernate-portfolio-vdb.xml
added primary key
