### PR TITLE
[CLOUD-2760] moving data directory to the shared space

### DIFF
--- a/jta-crash-rec-eap7/src/main/scripts/xa.btm
+++ b/jta-crash-rec-eap7/src/main/scripts/xa.btm
@@ -49,9 +49,12 @@ CLASS com.arjuna.ats.arjuna.coordinator.BasicAction
 METHOD phase2Commit
 AT ENTRY
 # if there are 2 XA resources per txn then set the countDown such that during
-# the VM will halt when the 2nd participant is asked to commit.
-# Note we alter the original behaviour to allow the first transaction to succeed,
-# this allows simpler verification of the recovery under OpenShift.
+#  the VM will halt when the 2nd participant is asked to commit.
+# The behavior was changed to allow simpler verification under OpenShift.
+#  First two transactions (each per 2 XA resources) are left to be committed.
+#  The first transaction belongs to servlet saving data, the second to MDB
+#  receiving message and updating data.
+#  The next time the servlet submits data the transaction is halt.
 IF TRUE
 DO traceln("Starting countdown at 5"), createCountDown("xahalt",5)
 ENDRULE

--- a/jta-crash-rec-eap7/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
+++ b/jta-crash-rec-eap7/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
     <xa-datasource jndi-name="java:jboss/datasources/JTACrashRecQuickstartDS" pool-name="JTACrashRecQuickstart" enabled="true">
         <xa-datasource-property name="URL">
-            jdbc:h2:file:${jboss.server.data.dir}/jta-crash-rec-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
+            jdbc:h2:file:${jboss.server.data.dir}/../../jta-crash-rec-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
         </xa-datasource-property>
         <driver>h2</driver>
         <xa-pool>


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2760

The quickstart fails as data are saved locally at the pod. For the quickstart example to work we need to move the location of data to some shared placed which is not local only to a pod where the pod data directory can  be removed as it's not expected to contain an application state.

/cc @knrc  can you please take a look?